### PR TITLE
Add POST files support

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,8 @@
+# UPGRADE
+
+## 1.0.2 to 1.1.0
+
+ * The third argument of the `HttpAdapterInterface::postContent` (ie. `$content`) is now typehinted as `array`
+   in order to be consistent with other parameters.
+ * The third argument of the `CurlHttpAdapter::execute` (ie. `$content`) is now typehinted as `array` in order to be
+   consistent with other parameters.

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-master": "1.1-dev"
         }
     }
 }

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -82,7 +82,7 @@ Each adapter allows you to make a GET request:
 $content = $httpAdapter->getContent($url);
 ```
 
-If you would like to pass custom headers, you can use the second argument:
+If you want to pass custom headers, you can use the second argument:
 
 ``` php
 $content = $httpAdapter->getContent($url, $headers);
@@ -96,14 +96,20 @@ Each adapter allows you to make a POST request:
 $content = $httpAdapter->postContent($url);
 ```
 
-If you would like to pass custom headers, you can use the second argument:
+If you want to pass custom headers, you can use the second argument:
 
 ``` php
 $content = $httpAdapter->postContent($url, $headers);
 ```
 
-If you would like to pass POST datas, you use the third argument:
+If you want to pass POST datas, you can use the third argument:
 
 ``` php
 $content = $httpAdapter->postContent($url, $headers, $data);
+```
+
+If you want to pass POST files, you can use the fourth argument:
+
+``` php
+$content = $httpAdapter->postContent($url, $headers, $data, $files);
 ```

--- a/src/Widop/HttpAdapter/BuzzHttpAdapter.php
+++ b/src/Widop/HttpAdapter/BuzzHttpAdapter.php
@@ -57,12 +57,17 @@ class BuzzHttpAdapter extends AbstractHttpAdapter
     /**
      * {@inheritdoc}
      */
-    public function postContent($url, array $headers = array(), $content = '')
+    public function postContent($url, array $headers = array(), array $content = array(), array $files = array())
     {
         $this->configure();
+        $post = $content;
+
+        if (!empty($files)) {
+            $post = array_merge($post, array_map(function($file) { return '@'.$file; }, $files));
+        }
 
         try {
-            return $this->browser->post($url, $headers, $content)->getContent();
+            return $this->browser->post($url, $headers, $post)->getContent();
         } catch (\Exception $e) {
             throw HttpAdapterException::cannotFetchUrl($url, $this->getName(), $e->getMessage());
         }

--- a/src/Widop/HttpAdapter/GuzzleHttpAdapter.php
+++ b/src/Widop/HttpAdapter/GuzzleHttpAdapter.php
@@ -60,12 +60,16 @@ class GuzzleHttpAdapter extends AbstractHttpAdapter
     /**
      * {@inheritdoc}
      */
-    public function postContent($url, array $headers = array(), $content = '')
+    public function postContent($url, array $headers = array(), array $content = array(), array $files = array())
     {
-        try {
-            $request = $this->client->post($url, $headers, $content);
-            $this->configure($request);
+        $request = $this->client->post($url, $headers, $content);
+        $this->configure($request);
 
+        foreach ($files as $key => $file) {
+            $request->addPostFile($key, $file);
+        }
+
+        try {
             return $request->send()->getBody(true);
         } catch (\Exception $e) {
             throw HttpAdapterException::cannotFetchUrl($url, $this->getName(), $e->getMessage());

--- a/src/Widop/HttpAdapter/HttpAdapterInterface.php
+++ b/src/Widop/HttpAdapter/HttpAdapterInterface.php
@@ -38,15 +38,16 @@ interface HttpAdapterInterface
     /**
      * Gets the content fetched from the given url & POST datas.
      *
-     * @param string       $url     The URL to request.
-     * @param array        $headers HTTP headers (optional).
-     * @param string|array $content The POST content (optional).
+     * @param string $url     The URL to request.
+     * @param array  $headers HTTP headers (optional).
+     * @param array  $content The POST content (optional).
+     * @param array  $files   The POST files (optional).
      *
      * @throws \Widop\HttpAdapter\HttpAdapterException If an error occured.
      *
      * @return string The fetched content.
      */
-    function postContent($url, array $headers = array(), $content = '');
+    function postContent($url, array $headers = array(), array $content = array(), array $files = array());
 
     /**
      * Gets the name of the Http adapter.

--- a/src/Widop/HttpAdapter/StreamHttpAdapter.php
+++ b/src/Widop/HttpAdapter/StreamHttpAdapter.php
@@ -11,6 +11,8 @@
 
 namespace Widop\HttpAdapter;
 
+use Widop\HttpAdapter\HttpAdapterException;
+
 /**
  * Stream Http adapter.
  *
@@ -30,9 +32,9 @@ class StreamHttpAdapter extends AbstractHttpAdapter
     /**
      * {@inheritdoc}
      */
-    public function postContent($url, array $headers = array(), $content = '')
+    public function postContent($url, array $headers = array(), array $content = array(), array $files = array())
     {
-        return $this->execute($url, $this->createStreamContext('POST', $headers, $content));
+        return $this->execute($url, $this->createStreamContext('POST', $headers, $content, $files));
     }
 
     /**
@@ -69,14 +71,21 @@ class StreamHttpAdapter extends AbstractHttpAdapter
     /**
      * Creates the stream context.
      *
-     * @param string       $method  The HTTP method.
-     * @param array        $headers The headers.
-     * @param string|array $content The content.
+     * @param string $method  The HTTP method.
+     * @param array  $headers The headers.
+     * @param array  $content The content.
+     * @param array  $files   The files.
+     *
+     * @throws \Widop\HttpAdapter\HttpAdapterException If there are files (not supported).
      *
      * @return resource A stream context resource.
      */
-    protected function createStreamContext($method, array $headers, $content = '')
+    protected function createStreamContext($method, array $headers, array $content = array(), array $files = array())
     {
+        if (!empty($files)) {
+            throw new HttpAdapterException(sprintf('The "%s" does not support files.', __CLASS__));
+        }
+
         $contextOptions = array('http' => array('method' => $method));
 
         if (!empty($headers)) {

--- a/src/Widop/HttpAdapter/ZendHttpAdapter.php
+++ b/src/Widop/HttpAdapter/ZendHttpAdapter.php
@@ -62,17 +62,22 @@ class ZendHttpAdapter extends AbstractHttpAdapter
     /**
      * {@inheritdoc}
      */
-    public function postContent($url, array $headers = array(), $content = '')
+    public function postContent($url, array $headers = array(), array $content = array(), array $files = array())
     {
         $this->configure();
 
+        $request = $this->client
+            ->setMethod('POST')
+            ->setUri($url)
+            ->setHeaders($headers)
+            ->setParameterPost($content);
+
+        foreach ($files as $key => $file) {
+            $request->setFileUpload($file, $key);
+        }
+
         try {
-            return $this->client
-                ->setUri($url)
-                ->setHeaders($headers)
-                ->setRawBody($this->fixContent($content))
-                ->send()
-                ->getBody();
+            return $request->send()->getBody();
         } catch (\Exception $e) {
             throw HttpAdapterException::cannotFetchUrl($url, $this->getName(), $e->getMessage());
         }

--- a/tests/Widop/Tests/HttpAdapter/AbstractHttpAdapterTest.php
+++ b/tests/Widop/Tests/HttpAdapter/AbstractHttpAdapterTest.php
@@ -65,24 +65,25 @@ abstract class AbstractHttpAdapterTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testPostContentWithHeadersAndStringData()
-    {
-        $this->assertNotEmpty(
-            $this->httpAdapter->postContent(
-                'http://www.widop.com',
-                array('Accept-Charset' => 'utf-8', 'Accept-Language: en-US,en;q=0.8'),
-                http_build_query(array('param' => 'value'))
-            )
-        );
-    }
-
-    public function testPostContentWithHeadersAndArrayData()
+    public function testPostContentWithHeadersAndContent()
     {
         $this->assertNotEmpty(
             $this->httpAdapter->postContent(
                 'http://www.widop.com',
                 array('Accept-Charset' => 'utf-8', 'Accept-Language: en-US,en;q=0.8'),
                 array('param' => 'value')
+            )
+        );
+    }
+
+    public function testPostContentWithHeadersAndContentAndFiles()
+    {
+        $this->assertNotEmpty(
+            $this->httpAdapter->postContent(
+                'http://www.widop.com',
+                array('Accept-Charset' => 'utf-8', 'Accept-Language: en-US,en;q=0.8'),
+                array('param' => 'value'),
+                array('file' => realpath(__DIR__.'/Fixtures/file.txt'))
             )
         );
     }

--- a/tests/Widop/Tests/HttpAdapter/StreamHttpAdapterTest.php
+++ b/tests/Widop/Tests/HttpAdapter/StreamHttpAdapterTest.php
@@ -32,4 +32,13 @@ class StreamHttpAdapterTest extends AbstractHttpAdapterTest
     {
         $this->assertSame('stream', $this->httpAdapter->getName());
     }
+
+    /**
+     * @expectedException \Widop\HttpAdapter\HttpAdapterException
+     * @expectedExceptionMessage The "Widop\HttpAdapter\StreamHttpAdapter" does not support files.
+     */
+    public function testPostContentWithHeadersAndContentAndFiles()
+    {
+        parent::testPostContentWithHeadersAndContentAndFiles();
+    }
 }


### PR DESCRIPTION
This PR adds the POST files support by adding a new argument to the `postContent` method. Additionally, it breaks BC by typehinting the content as array. IMO, as everywhere we use array, it should be same for the content.

For now, all adapters support it except the stream one.
